### PR TITLE
Feat/51

### DIFF
--- a/src/controllers/sentiment.controller.js
+++ b/src/controllers/sentiment.controller.js
@@ -11,6 +11,7 @@ import jwt from 'jsonwebtoken';
 import { insertComment, deleteComment, insertSentiment, updateSentiment, deleteSentiment } from './../services/sentiment.service.js';
 import { readSentiment, readComment } from './../providers/sentiment.provider.js';
 import { getUser } from "../models/user.dao.js";
+import { sentimentListProv, sentimentFollowProv} from '../providers/sentiment.provider.js';
 
 dotenv.config();
 
@@ -103,4 +104,24 @@ export const getAlarm = async (req, res, next) => {
 export const updateAlarm = async (req, res, next) => {
     console.log("알림 상태 업데이트 요청");
     res.send(response(status.SUCCESS, await updateAlarmService(req.params.userId, req.params.alarmId)));
+}
+
+// 센티멘트 리스트 조회
+export const sentimentList = async (req, res, next) => {
+    console.log("센티멘트 리스트 조회 요청");
+    try {
+        const result = await sentimentListProv(req.query.page || 1);
+        res.send(response(status.SUCCESS, result));
+    } catch (error) {
+        console.error(error);
+        res.status(500).send('Internal Server Error');
+    }
+}
+
+
+// 팔로우한 사람 센티멘트 리스트 조회
+export const sentimentListFollowing = async (req, res, next) => {
+    console.log("팔로우한 사람의 센티멘트 리스트 조회 요청");
+    res.send(response(status.SUCCESS, await sentimentFollowProv(req.params.userId, req.query.page || 1)));
+
 }

--- a/src/dtos/sentiment.response.dto.js
+++ b/src/dtos/sentiment.response.dto.js
@@ -69,7 +69,7 @@ export const sentimentListDTO = (data) => {
         "author" : item.author,
         "publisher" : item.publisher,
         "nickname" : item.author_nickname,
-        "tier" : item.tier, // tier 값이 어디서 오는지 확인 필요
+        "tier" : item.tier, 
         "like_count" : item.total_likes,
         "comment_count" : item.total_comments,
         "scrap_count" : item.total_scraps,

--- a/src/dtos/sentiment.response.dto.js
+++ b/src/dtos/sentiment.response.dto.js
@@ -60,3 +60,20 @@ export const DeleteCommentResponseDTO = () => {
     console.log("DeleteCommentResponseDTO clear");
     return {"message" : "댓글이 삭제되었습니다"};
 }
+
+// sentimentListDTO
+export const sentimentListDTO = (data) => {
+    return data.map(item => ({
+        "sentiment_title" : item.sentiment_title,
+        "book_title" : item.book_title,
+        "author" : item.author,
+        "publisher" : item.publisher,
+        "nickname" : item.author_nickname,
+        "tier" : item.tier, // tier 값이 어디서 오는지 확인 필요
+        "like_count" : item.total_likes,
+        "comment_count" : item.total_comments,
+        "scrap_count" : item.total_scraps,
+        "created_date" : formatDate(item.created_at),
+        "score" : item.score
+    }));
+}

--- a/src/models/sentiment.dao.js
+++ b/src/models/sentiment.dao.js
@@ -10,6 +10,7 @@ import { insertCommentQuery, insertUserCommentQuery, selectInsertedCommentQuery,
          deleteCommentQuery, deleteUserCommentQuery, insertAlarmQuery,
          totalSentiment, totalRecommend, updateTier, getTierId, tierAlarm, getCommentList } from "./../models/sentiment.sql.js";
 import { getAlarmInfo, alarmStatus, getAlarmStatus } from "./sentiment.sql.js";
+import { getSentimentListSql, getFollowingSentimentListSql } from "./sentiment.sql.js";
 import { deleteImageFromS3 } from '../middleware/imageUploader.js';
 
 function isValidUrl(string) {
@@ -425,3 +426,41 @@ export const removeComment = async (commentId) => {
         throw err;
     }    
 };
+
+// 센티멘트 리스트 조회
+export const getSentimentListDao = async (page_num) => {
+    try {
+        const conn = await pool.getConnection();
+        const [list] = await conn.query(getSentimentListSql(), [(page_num-1) * 3]);
+
+        if (list.length == 0) {
+            return -1;
+        }
+
+        conn.release();
+        return list;
+    } catch (err) {
+        console.error(err);
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+}
+
+
+// 팔로우한 사람의 센티멘트 리스트 조회
+export const getSentimentFollowDao = async (userId, page_num) => {
+    try {
+        const conn = await pool.getConnection();
+        const [list] = await conn.query(getFollowingSentimentListSql(), [userId, (page_num-1) * 3]);
+
+
+        if (list.length == 0) {
+            return { message :"조회된 센티멘트가 없습니다."};
+        }
+
+        conn.release();
+        return list;
+    } catch (err) {
+        console.error(err);
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+}

--- a/src/models/sentiment.dao.js
+++ b/src/models/sentiment.dao.js
@@ -434,7 +434,7 @@ export const getSentimentListDao = async (page_num) => {
         const [list] = await conn.query(getSentimentListSql(), [(page_num-1) * 3]);
 
         if (list.length == 0) {
-            return -1;
+            return { message :"조회된 센티멘트가 없습니다."};
         }
 
         conn.release();

--- a/src/models/sentiment.sql.js
+++ b/src/models/sentiment.sql.js
@@ -72,3 +72,36 @@ export const tierAlarm = "INSERT INTO alarm (user_id, title, content, read_at, c
 export const alarmStatus = "UPDATE alarm SET read_at = 1 WHERE alarm_id=?;";
 export const getAlarmStatus = "SELECT read_at FROM alarm WHERE alarm_id=?";
 export const getAlarmInfo = "SELECT title, content, read_at, created_at FROM alarm WHERE user_id= ?;";
+
+// 센티멘트 리스트 조회
+export const getSentimentListSql = () => `
+    SELECT s.sentiment_title, s.book_title, u.nickname as nickname, 
+        ut.tier_id as tier,
+        (SELECT COUNT(*) FROM user_sentiment us WHERE us.sentiment_id = s.sentiment_id) as total_likes,
+        (SELECT COUNT(*) FROM user_sentiment us WHERE us.sentiment_id = s.sentiment_id AND us.scrap = true) as total_scraps,
+        (SELECT COUNT(*) FROM comment c WHERE c.sentiment_id = s.sentiment_id) as total_comments,
+        s.book_image, s.author, s.publisher, s.score, s.created_at
+    FROM sentiment s
+    JOIN user u ON s.user_id = u.user_id
+    JOIN user_tier ut ON u.user_id = ut.user_id
+    ORDER BY s.created_at DESC
+    LIMIT 3 OFFSET ?;
+`;
+
+export const getFollowingSentimentListSql = () => `
+    SELECT s.sentiment_title, s.book_title, u.nickname as nickname, 
+        ut.tier_id as tier,
+        (SELECT COUNT(*) FROM user_sentiment us WHERE us.sentiment_id = s.sentiment_id) as total_likes,
+        (SELECT COUNT(*) FROM user_sentiment us WHERE us.sentiment_id = s.sentiment_id AND us.scrap = true) as total_scraps,
+        (SELECT COUNT(*) FROM comment c WHERE c.sentiment_id = s.sentiment_id) as total_comments,
+        s.book_image, s.author, s.publisher, s.score, s.created_at
+    FROM sentiment s
+    JOIN user u ON s.user_id = u.user_id
+    JOIN user_tier ut ON u.user_id = ut.user_id
+    WHERE s.user_id IN (
+        SELECT following_id FROM follow WHERE follower_id = ?
+    )
+    ORDER BY s.created_at DESC
+    LIMIT 3 OFFSET ?;
+`;
+

--- a/src/providers/sentiment.provider.js
+++ b/src/providers/sentiment.provider.js
@@ -1,8 +1,10 @@
-// sentiment.provider.js
+
 import { BaseError } from "../../config/error.js";
 import { status } from "../../config/response.status.js";
 import { getSentiment, getComment } from "../models/sentiment.dao.js";
-import { sentimentResponseDTO, commentResponseDTO } from "./../dtos/sentiment.response.dto.js"
+import { getSentimentListDao, getSentimentFollowDao } from "../models/sentiment.dao.js";
+import { sentimentResponseDTO, commentResponseDTO } from "./../dtos/sentiment.response.dto.js";
+import { sentimentListDTO } from "./../dtos/sentiment.response.dto.js";
 
 // 센티멘트 조회
 export const readSentiment = async (sentimentId) => {
@@ -17,4 +19,18 @@ export const readComment = async (sentimentId) => {
     const comment = await getComment(sentimentId);
 
     return commentResponseDTO(comment);
+}
+
+// 센티멘트 리스트 조회 
+export const sentimentListProv = async (page_num) => {
+    const list = await getSentimentListDao(page_num);
+
+    return sentimentListDTO(list);
+}
+
+// 팔로우한 사람의 센티멘트 리스트 조회
+export const sentimentFollowProv = async (userId, page_num) => {
+    const list = await getSentimentFollowDao(userId, page_num);
+
+    return sentimentListDTO(list);
 }

--- a/src/routes/sentiment.route.js
+++ b/src/routes/sentiment.route.js
@@ -37,7 +37,7 @@ alarmtRouter.get('/', asyncHandler(getAlarm));
 alarmtRouter.patch('/', asyncHandler(updateAlarm));
 
 // 센티멘트 리스트 조회
-sentimentRouter.get('/sentimentlist', asyncHandler(sentimentList));
+sentimentRouter.get('/', asyncHandler(sentimentList));
 
 // 팔로우한 사람의 센티멘트 리스트 조회
 sentimentRouter.get('/follow/:userId', asyncHandler(sentimentListFollowing));

--- a/src/routes/sentiment.route.js
+++ b/src/routes/sentiment.route.js
@@ -7,6 +7,8 @@ import { upload } from '../middleware/imageUploader.js';
 import { wrSentiment, rewrSentiment, delSentiment, getSentiment } from "../controllers/sentiment.controller.js";
 import { getAlarm, updateAlarm } from "../controllers/sentiment.controller.js";
 import { wrComment, delComment } from "../controllers/sentiment.controller.js";
+import { sentimentList, sentimentListFollowing } from "../controllers/sentiment.controller.js";
+
 export const sentimentRouter = express.Router({mergeParams: true});
 export const alarmtRouter = express.Router({mergeParams: true});
 
@@ -33,3 +35,9 @@ alarmtRouter.get('/', asyncHandler(getAlarm));
 
 // 알림 상태 업데이트
 alarmtRouter.patch('/', asyncHandler(updateAlarm));
+
+// 센티멘트 리스트 조회
+sentimentRouter.get('/sentimentlist', asyncHandler(sentimentList));
+
+// 팔로우한 사람의 센티멘트 리스트 조회
+sentimentRouter.get('/follow/:userId', asyncHandler(sentimentListFollowing));


### PR DESCRIPTION
index.js
- 기존 sentimentRouter 사용

sentiment.route.js
- GET 요청 
1. sentiments/ : 전체 센티멘트 리스트
2. sentiments/follow/:userId : 팔로우한 사람의 센티멘트 리스트

sentiment.controller.js
- sentimentList 컨트롤러 구현 : 쿼리값 전달
- sentimentListFollowing 컨트롤러 : 파라미터, 쿼리값 전달

sentiment.response.dto.js
- sentimentListDTO : 랭크, 티어, 닉네임, 상태메시지, 센티멘트 개수, 총 추천수 반

sentiment.provider.js
- sentimentListProv : 쿼리값(페이지 넘버) dao로 전달 후 리턴값 DTO로 반환
- sentimentFollowProv : 쿼리값(페이지 넘버), 파라미터(userId) dao로 전달 후 리턴값 DTO로 반환

sentiment.dao.js
- getSentimentListDao : page_num으로 쿼리 실행 후 값 객체 반환
- getSentimentFollowDao : userId, page_num으로 쿼리 실행 후 값 객체 반환

sentiment.sql.js
- getSentimentListSql : 전체 센티멘트와 작성자 관련 정보를 조회하여 리스트로 반환, 커서페이징으로 한 페이지 당 3개씩 조회
- getFollowingSentimentListSql : userId로 팔로우한  사람의 센티멘트 관련 정보를 조회하여 리스트로 반환, 커서페이징으로 한 페이지 당 3개씩 조회